### PR TITLE
Fix byte-compile warning

### DIFF
--- a/cargo-mode.el
+++ b/cargo-mode.el
@@ -46,6 +46,8 @@
 
 ;;; Code:
 
+(require 'subr-x)
+
 (defcustom cargo-path-to-bin
   (or (executable-find "cargo")
       "~/.cargo/bin/cargo")


### PR DESCRIPTION
```
cargo-mode.el:289:1:Warning: the function ‘string-trim-left’ is not known to be defined.
```