### PR TITLE
Fix typo in minor-mode definition

### DIFF
--- a/cargo-mode.el
+++ b/cargo-mode.el
@@ -282,7 +282,7 @@ If PREFIX is non-nil, prompt for additional params."
 (define-minor-mode cargo-minor-mode
   "Cargo minor mode.  Used to hold keybindings for `cargo-mode'.
 \\{cargo-minor-mode-map}"
-  :int-value nil
+  :init-value nil
   :lighter " cargo"
   :keymap cargo-minor-mode-map)
 


### PR DESCRIPTION
I'm really sorry! There was a typo in the last commit.