### PR TITLE
Clarify the purpose of `C-u` in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ To change prefix (default <kbd>C-q e</kbd>) use:
 
 ## Modify a command before execution
 
-Use `C-u` to add extra command line params before executing a command.
+Use prefix argument (default `C-u`) to add extra command line params before executing a command.
 
 ## Contributing
 


### PR DESCRIPTION
A very minor change on wording. Reasons: while `C-u` is well known among emacs users, some might still use another keybinding for it