### PR TITLE
Changes to the default keybinds for `cargo-mode` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,21 +18,23 @@ Cargo is the Rust package manager.
 
 ### MELPA
 
-Set up the MELPA or MELPA Stable repository if you haven't already and install with M-x package-install RET cargo-mode RET.
+Set up the MELPA (or MELPA Stable) if you haven't already, and install with `M-x package-install RET cargo-mode RET`.
 
-Or you can use `use-package`:
+The relevant form for `use-package` users is:
 
-```lisp
+```el
 (use-package cargo-mode
+  :hook
+  (rust-mode . cargo-minor-mode)
   :config
-  (add-hook 'rust-mode-hook 'cargo-minor-mode))
+  (setq compilation-scroll-output t))
 ```
 
 ### From file
 
 Add `cargo-mode.el` to your load path:
 
-``` lisp
+```el
 (add-to-list 'load-path "path/to/cargo-mode.el")
 ```
 

--- a/README.md
+++ b/README.md
@@ -40,38 +40,38 @@ Add `cargo-mode.el` to your load path:
 
 Add a hook to the mode that you're using with Rust, for example, `rust-mode`:
 
-``` lisp
+```el
 (add-hook 'rust-mode-hook 'cargo-minor-mode)
 ```
 
 Set `compilation-scroll-output` to non-nil to scroll the *cargo-mode* buffer window as output appears. The value ‘first-error’ stops scrolling at the first error, and leaves point on its location in the *cargo-mode* buffer. For example:
 
-``` lisp
+```el
 (setq compilation-scroll-output t)
 ```
 
 ## Usage
 
-<kbd> C-q e e </kbd> - `cargo-execute-task` - List all available tasks and execute one of them.  As a bonus, you'll get a documentation string because `cargo-mode.el` parses shell output of `cargo --list` directly.
+<kbd> C-c a e </kbd> - `cargo-execute-task` - List all available tasks and execute one of them.  As a bonus, you'll get a documentation string because `cargo-mode.el` parses shell output of `cargo --list` directly.
 
-<kbd> C-q e t </kbd> - `cargo-mode-test` - Run all tests in the project (`cargo test`).
+<kbd> C-c a t </kbd> - `cargo-mode-test` - Run all tests in the project (`cargo test`).
 
-<kbd> C-q e l </kbd> - `cargo-mode-last-command` - Execute the last executed command.
+<kbd> C-c a l </kbd> - `cargo-mode-last-command` - Execute the last executed command.
 
-<kbd> C-q e b </kbd> - `cargo-mode-build` - Build the project (`cargo build`).
+<kbd> C-c a b </kbd> - `cargo-mode-build` - Build the project (`cargo build`).
 
 
-<kbd> C-q e o </kbd> - `cargo-mode-test-current-buffer` - Run all tests in the current buffer.
+<kbd> C-c a o </kbd> - `cargo-mode-test-current-buffer` - Run all tests in the current buffer.
 
-<kbd> C-q e f </kbd> - `cargo-mode-test-current-test` - Run the current test where pointer is located.
+<kbd> C-c a f </kbd> - `cargo-mode-test-current-test` - Run the current test where pointer is located.
 
 
 These are all commands that I use most frequently. You can execute any cargo command (fmt, clean etc) available in the project using `cargo-mode-execute-task`. If you have suggestions for additional commands to add keybindings to, please create an issue.
 
-To change prefix (default <kbd>C-q e</kbd>) use:
+To change the prefix (default <kbd>C-c a</kbd>) use:
 
 ```el
- (define-key cargo-minor-mode-map (kbd ...) 'cargo-mode-command-map)
+ (keymap-set cargo-minor-mode-map (kbd ...) 'cargo-mode-command-map)
 ```
 
 ## Modify a command before execution

--- a/cargo-mode.el
+++ b/cargo-mode.el
@@ -35,12 +35,12 @@
 ;; (add-hook 'rust-mode-hook 'cargo-minor-mode)
 ;;
 
-;;; C-q e e - `cargo-execute-task` - List all available tasks and execute one of them.  As a bonus, you'll get a documentation string because `cargo-mode.el` parses shell output of `cargo --list` directly.
-;;; C-q e t - `cargo-mode-test` - Run all tests in the project (`cargo test`).
-;;; C-q e l - `cargo-mode-last-command` - Execute the last executed command.
-;;; C-q e b - `cargo-mode-build` - Build the project (`cargo build`).
-;;; C-q e o - `cargo-mode-test-current-buffer` - Run all tests in the current buffer.
-;;; C-q e f - `cargo-mode-test-current-test` - Run the current test where pointer is located.
+;;; C-c a e - `cargo-execute-task` - List all available tasks and execute one of them.  As a bonus, you'll get a documentation string because `cargo-mode.el` parses shell output of `cargo --list` directly.
+;;; C-c a t - `cargo-mode-test` - Run all tests in the project (`cargo test`).
+;;; C-c a l - `cargo-mode-last-command` - Execute the last executed command.
+;;; C-c a b - `cargo-mode-build` - Build the project (`cargo build`).
+;;; C-c a o - `cargo-mode-test-current-buffer` - Run all tests in the current buffer.
+;;; C-c a f - `cargo-mode-test-current-test` - Run the current test where pointer is located.
 ;;;
 ;;; Use `C-u` to add extra command line params before executing a command.
 
@@ -274,13 +274,13 @@ If PREFIX is non-nil, prompt for additional params."
 
 (defvar cargo-minor-mode-map
   (let ((map (make-sparse-keymap)))
-    (define-key map (kbd "C-q e") 'cargo-mode-command-map)
+    (define-key map (kbd "C-c a") 'cargo-mode-command-map)
     map)
   "Cargo-map keymap.")
 
 ;;;###autoload
 (define-minor-mode cargo-minor-mode
-  "Cargo minor mode.  Used to hold keybindings for `cargo-mode'.
+  "Cargo minor mode.  Used for holding keybindings for `cargo-mode'.
 \\{cargo-minor-mode-map}"
   :init-value nil
   :lighter " cargo"

--- a/cargo-mode.el
+++ b/cargo-mode.el
@@ -24,7 +24,7 @@
 
 ;; Author: Ayrat Badykov <ayratin555@gmail.com>
 ;; URL: https://github.com/ayrat555/cargo-mode
-;; Version  : 0.0.2
+;; Version  : 0.0.3
 ;; Keywords: tools
 ;; Package-Requires: ((emacs "25.1"))
 

--- a/cargo-mode.el
+++ b/cargo-mode.el
@@ -254,7 +254,7 @@ If PREFIX is non-nil, prompt for additional params."
 
 ;;;###autoload
 (defun cargo-mode-last-command ()
-  "Execute the last `cargo-mode` task."
+  "Re-execute the last `cargo-mode` task."
   (interactive)
   (if cargo-mode--last-command
       (apply #'cargo-mode--start cargo-mode--last-command)


### PR DESCRIPTION
#### Summary

Changed the default prefix from `C-q e` to `C-c a` to better conform to user expectations. 

#### Motivation

The `C-q` is an emacs-specific rarely re-bound command that is used to bypass any special bindings and to do unconditional `self-insert` overriding it is a bad idea, particularly because users might be unable to re-override the override. 

Instead, almost all user-facing packages are expected to use the `C-c` prefix. `C-c a` was chosen because it's an initialism of Cargo. 

Additionally I've adjusted the Readme and bumped the version to 0.0.3

#### Copyright

This work is copyright assigned to  Ayrat Badykov (please update the copyright notice to 2023 or better to 2024). 

#### Github

Closes  #7. 
