### PR TITLE
Run compile without comint

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ Set `compilation-scroll-output` to non-nil to scroll the *cargo-mode* buffer win
 (setq compilation-scroll-output t)
 ```
 
+By default `cargo-mode` use `comint` mode for compilation buffer. Set `cargo-mode-use-comint` to nil to use `compilation` mode instead.
+
+```el
+(use-package cargo-mode
+  :custom
+  (cargo-mode-use-comint nil))
+```
+
 ## Usage
 
 <kbd> C-q e e </kbd> - `cargo-execute-task` - List all available tasks and execute one of them.  As a bonus, you'll get a documentation string because `cargo-mode.el` parses shell output of `cargo --list` directly.

--- a/cargo-mode.el
+++ b/cargo-mode.el
@@ -55,6 +55,11 @@
   :type 'file
   :group 'cargo-mode)
 
+(defcustom cargo-mode-use-comint t
+  "If t `compile' runs with comint option paramater."
+  :type 'boolean
+  :group 'cargo-mode)
+
 (defcustom cargo-mode-command-test "test"
   "Subcommand used by `cargo-mode-test'."
   :type 'string
@@ -145,7 +150,7 @@ If PROMPT is non-nil, modifies the command."
                               buffer-file-name
                               (string-prefix-p project-root (file-truename buffer-file-name)))))
     (setq cargo-mode--last-command (list name cmd project-root))
-    (compile cmd nil)
+    (if cargo-mode-use-comint (compile cmd t) (compile cmd nil))
     (get-buffer-process buffer)))
 
 (defun cargo-mode--project-directory ()

--- a/cargo-mode.el
+++ b/cargo-mode.el
@@ -145,7 +145,7 @@ If PROMPT is non-nil, modifies the command."
                               buffer-file-name
                               (string-prefix-p project-root (file-truename buffer-file-name)))))
     (setq cargo-mode--last-command (list name cmd project-root))
-    (compile cmd t)
+    (compile cmd nil)
     (get-buffer-process buffer)))
 
 (defun cargo-mode--project-directory ()


### PR DESCRIPTION
Hello @ayrat555,

Thank you for this package.

When running `compile` resulting `*compilation*` buffer should not use comint major mode. (comint is for shell like interpeters)