### PR TITLE
fix: use beginning-of-defun-raw for current test

### DIFF
--- a/cargo-mode.el
+++ b/cargo-mode.el
@@ -184,12 +184,10 @@ If PROMPT is non-nil, modifies the command."
   "Return the current test."
   (save-excursion
     (unless (cargo-mode--defun-at-point-p)
-      (cond ((fboundp 'rust-beginning-of-defun)
-	     (rust-beginning-of-defun))
-	    ((fboundp 'rustic-beginning-of-defun)
-	     (rustic-beginning-of-defun))
-	    (t (user-error "%s needs either rust-mode or rustic-mode"
-			   this-command))))
+      (if beginning-of-defun-function
+          (beginning-of-defun-raw)
+          (user-error "%s needs a supported major mode like rust-mode or rustic-mode"
+		      this-command)))
     (beginning-of-line)
     (search-forward "fn ")
     (let* ((line (buffer-substring-no-properties (point)


### PR DESCRIPTION
I got error that `cargo-test-current-test` only supports rust-mode or rustic-mode while using the `rust-ts-mode`. After digging into the detail, I found there is a generic `beginning-of-defun-raw` that supported by most major modes.

This patch switches from hard-coded function to this generic one.