### PR TITLE
feat: use custom compilation mode with keybindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Set `compilation-scroll-output` to non-nil to scroll the *cargo-compile-mode* bu
 (setq compilation-scroll-output t)
 ```
 
-By default `cargo-mode` use `comint` mode for compilation buffer. Set `cargo-mode-use-comint` to nil to use `compilation` mode instead.
+By default `cargo-mode` use `comint` mode for compilation buffer. Set `cargo-mode-use-comint` to nil to disable it.
 
 ```el
 (use-package cargo-mode

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Add a hook to the mode that you're using with Rust, for example, `rust-mode`:
 (add-hook 'rust-mode-hook 'cargo-minor-mode)
 ```
 
-Set `compilation-scroll-output` to non-nil to scroll the *cargo-mode* buffer window as output appears. The value ‘first-error’ stops scrolling at the first error, and leaves point on its location in the *cargo-mode* buffer. For example:
+Set `compilation-scroll-output` to non-nil to scroll the *cargo-compile-mode* buffer window as output appears. The value ‘first-error’ stops scrolling at the first error, and leaves point on its location in the *cargo-mode* buffer. For example:
 
 ```el
 (setq compilation-scroll-output t)

--- a/cargo-mode.el
+++ b/cargo-mode.el
@@ -82,7 +82,7 @@
                                 (executable-find "cargo" t) (executable-find "cargo"))
                             "~/.cargo/bin/cargo")))
 
-(define-derived-mode cargo-compile-mode compilation-mode "Cargo"
+(define-derived-mode cargo-compilation-mode compilation-mode "Cargo"
   "Major mode for the Cargo buffer."
   (message "using custom mode")
   (setq buffer-read-only t)
@@ -160,7 +160,7 @@ If PROMPT is non-nil, modifies the command."
                               buffer-file-name
                               (string-prefix-p project-root (file-truename buffer-file-name)))))
     (setq cargo-mode--last-command (list name cmd project-root))
-    (compilation-start cmd 'cargo-compile-mode)
+    (compilation-start cmd 'cargo-compilation-mode)
     (get-buffer-process buffer)))
 
 (defun cargo-mode--project-directory ()

--- a/cargo-mode.el
+++ b/cargo-mode.el
@@ -54,11 +54,6 @@
   :type 'file
   :group 'cargo-mode)
 
-(defcustom cargo-mode-use-comint t
-  "If t `compile' runs with comint option paramater."
-  :type 'boolean
-  :group 'cargo-mode)
-
 (defcustom cargo-mode-command-test "test"
   "Subcommand used by `cargo-mode-test'."
   :type 'string
@@ -82,10 +77,13 @@
                                 (executable-find "cargo" t) (executable-find "cargo"))
                             "~/.cargo/bin/cargo")))
 
-(define-derived-mode cargo-mode compilation-mode "Cargo"
+(define-derived-mode cargo-compile-mode compilation-mode "Cargo"
   "Major mode for the Cargo buffer."
+  (message "using custom mode")
   (setq buffer-read-only t)
-  (setq-local truncate-lines t))
+  (setq-local truncate-lines t)
+  (local-set-key (kbd "q") 'kill-buffer-and-window)
+  (local-set-key (kbd "g") 'cargo-mode-last-command))
 
 (defun cargo-mode--fetch-cargo-tasks (project-root)
   "Fetch list of raw commands from shell for project in PROJECT-ROOT."
@@ -155,7 +153,7 @@ If PROMPT is non-nil, modifies the command."
                               buffer-file-name
                               (string-prefix-p project-root (file-truename buffer-file-name)))))
     (setq cargo-mode--last-command (list name cmd project-root))
-    (compile cmd cargo-mode-use-comint)
+    (compilation-start cmd 'cargo-compile-mode)
     (get-buffer-process buffer)))
 
 (defun cargo-mode--project-directory ()

--- a/cargo-mode.el
+++ b/cargo-mode.el
@@ -54,6 +54,11 @@
   :type 'file
   :group 'cargo-mode)
 
+(defcustom cargo-mode-use-comint t
+  "If t `compile' runs with comint option paramater."
+  :type 'boolean
+  :group 'cargo-mode)
+
 (defcustom cargo-mode-command-test "test"
   "Subcommand used by `cargo-mode-test'."
   :type 'string
@@ -82,6 +87,8 @@
   (message "using custom mode")
   (setq buffer-read-only t)
   (setq-local truncate-lines t)
+  (if cargo-mode-use-comint
+    (compilation-shell-minor-mode))
   (local-set-key (kbd "q") 'kill-buffer-and-window)
   (local-set-key (kbd "g") 'cargo-mode-last-command))
 


### PR DESCRIPTION
Fixes #18 

This patch uses our own `cargo-compile-mode`, renamed from `cargo-mode` to avoid confusion, for compilation results. It also adds keybindings like `q` for quit, `g` for retry.